### PR TITLE
Refactor some X11 code around

### DIFF
--- a/lib/msf/core/exploit/remote/x11.rb
+++ b/lib/msf/core/exploit/remote/x11.rb
@@ -3,4 +3,5 @@
 module Msf::Exploit::Remote::X11
   include Msf::Exploit::Remote::X11::Connect
   include Msf::Exploit::Remote::X11::Extension
+  include Msf::Exploit::Remote::X11::Read
 end

--- a/lib/msf/core/exploit/remote/x11/connect.rb
+++ b/lib/msf/core/exploit/remote/x11/connect.rb
@@ -36,7 +36,7 @@ module Msf::Exploit::Remote::X11::Connect
 
   # print out the information for an x11 connection which was
   # successfully established
-  def print_connection_info(connection, ip, port)
+  def x11_print_connection_info(connection, ip, port)
     print_good("#{ip} - Successfully established X11 connection")
     vprint_status("  Vendor: #{connection.body.vendor}")
     vprint_status("  Version: #{connection.header.protocol_version_major}.#{connection.header.protocol_version_minor}")

--- a/lib/msf/core/exploit/remote/x11/extension.rb
+++ b/lib/msf/core/exploit/remote/x11/extension.rb
@@ -7,26 +7,17 @@
 #
 
 module Msf::Exploit::Remote::X11::Extension
+  include Msf::Exploit::Remote::X11::Read
   include Rex::Proto::X11::Extension
 
   # Query for an extension, converts the name of the extension to the ID #
-  def query_extension(extension_name, call_count)
+  def x11_query_extension(extension_name, call_count)
     sock.put(X11QueryExtensionRequest.new(extension: extension_name, unused2: call_count).to_binary_s)
-    packet = ''
-    result = nil
-    begin
-      packet = sock.timed_read(X11QueryExtensionResponse.new.num_bytes)
-      # for debugging, print the following line
-      # puts packet.bytes.map { |b| '\\x' + b.to_s(16).rjust(2, '0') }.join
-      result = X11QueryExtensionResponse.read(packet)
-    rescue StandardError => e
-      vprint_bad("Error (#{e}) processing data: #{packet.bytes.map { |b| %(\\x) + b.to_s(16).rjust(2, '0') }.join}")
-    end
-    result
+    x11_read_response(X11QueryExtensionResponse)
   end
 
   # toggles an extension on or off (enable/disable)
-  def toggle_extension(extension_id, wanted_major: 0, toggle: true)
+  def x11_toggle_extension(extension_id, wanted_major: 0, toggle: true)
     sock.put(
       X11ExtensionToggleRequest.new(
         opcode: extension_id,
@@ -34,14 +25,6 @@ module Msf::Exploit::Remote::X11::Extension
         wanted_major: wanted_major
       ).to_binary_s
     )
-    packet = ''
-    result = nil
-    begin
-      packet = sock.timed_read(X11ExtensionToggleReply.new.num_bytes)
-      result = X11ExtensionToggleReply.read(packet)
-    rescue StandardError => e
-      vprint_bad("Error (#{e}) processing data: #{packet.bytes.map { |b| %(\\x) + b.to_s(16).rjust(2, '0') }.join}")
-    end
-    result
+    x11_read_response(X11ExtensionToggleResponse)
   end
 end

--- a/lib/msf/core/exploit/remote/x11/read.rb
+++ b/lib/msf/core/exploit/remote/x11/read.rb
@@ -1,0 +1,46 @@
+# -*- coding: binary -*-
+
+module Msf::Exploit::Remote::X11::Read
+  def x11_read_response(klass, timeout: 10)
+    unless klass.fields.field_name?(:response_length)
+      raise ::ArgumentError, 'X11 class must have the response_length field to be read'
+    end
+
+    remaining = timeout
+    reply_instance = klass.new
+
+    metalength = reply_instance.response_length.num_bytes
+    buffer, elapsed_time = Rex::Stopwatch.elapsed_time do
+      sock.read(reply_instance.response_length.abs_offset + metalength, remaining)
+    end
+    raise ::EOFError, 'X11: failed to read response' if buffer.nil?
+
+    remaining -= elapsed_time
+
+    # see: https://www.x.org/releases/X11R7.7/doc/xproto/x11protocol.html#request_format
+    response_length = reply_instance.response_length.read(buffer[-metalength..]).value
+    response_length *= 4 # field is in 4-byte units
+    response_length += 32 # 32 byte header is not included
+
+    while buffer.length < response_length && remaining > 0
+      chunk, elapsed_time = Rex::Stopwatch.elapsed_time do
+        sock.read(response_length - buffer.length, remaining)
+      end
+
+      remaining -= elapsed_time
+      break if chunk.nil?
+
+      buffer << chunk
+    end
+
+    unless buffer.length == response_length
+      if remaining <= 0
+        raise Rex::TimeoutError, 'X11: failed to read response due to timeout'
+      end
+
+      raise ::EOFError, 'X11: failed to read response'
+    end
+
+    reply_instance.read(buffer)
+  end
+end

--- a/lib/rex/proto/x11.rb
+++ b/lib/rex/proto/x11.rb
@@ -26,7 +26,7 @@ module Rex::Proto::X11
   end
 
   # https://xcb.freedesktop.org/manual/structxcb__get__property__reply__t.html
-  class X11GetPropertyResponseHeader < BinData::Record
+  class X11GetPropertyResponse < BinData::Record
     endian :little
     uint8 :reply
     uint8 :format
@@ -35,19 +35,8 @@ module Rex::Proto::X11
     uint32 :get_property_type # 8bit boolean, \x01 == true \x00 == false
     uint32 :bytes_after
     uint32 :value_length
-    uint32 :pad0
-    uint32 :pad1
-    uint32 :pad2
-  end
-
-  # https://xcb.freedesktop.org/manual/structxcb__get__property__reply__t.html
-  class X11GetPropertyResponseData < BinData::Record
+    uint8_array :pad0, initial_length: 12
     rest :value_data
-  end
-
-  class X11GetPropertyResponse < BinData::Record
-    x11_get_property_response_header :header
-    x11_get_property_response_data   :data
   end
 
   # https://xcb.freedesktop.org/manual/structxcb__intern__atom__reply__t.html

--- a/lib/rex/proto/x11/extension.rb
+++ b/lib/rex/proto/x11/extension.rb
@@ -18,10 +18,6 @@ module Rex::Proto::X11::Extension
     uint8 :major_opcode # this is the ID of the extension
     uint8 :first_event
     uint8 :first_error
-    # 64 + 64 + 32 padding 'undecoded' in wireshark
-    uint64 :pad1
-    uint64 :pad2
-    uint32 :pad3
   end
 
   # https://xcb.freedesktop.org/manual/structxcb__query__extension__request__t.html
@@ -50,16 +46,12 @@ module Rex::Proto::X11::Extension
   end
 
   # built based on Wireshark processor
-  class X11ExtensionToggleReply < BinData::Record
+  class X11ExtensionToggleResponse < BinData::Record
     endian :little
     uint8 :reply
     uint8 :pad0
-    uint16 :reply_sequence_number
-    uint32 :reply_length
+    uint16 :sequence_number
+    uint32 :response_length
     uint32 :maximum_request_length
-    # 64 + 64 + 32 padding 'undecoded' in wireshark
-    uint64 :pad1
-    uint64 :pad2
-    uint32 :pad3
   end
 end

--- a/lib/rex/proto/x11/xkeyboard.rb
+++ b/lib/rex/proto/x11/xkeyboard.rb
@@ -150,7 +150,7 @@ module Rex::Proto::X11::Xkeyboard
   end
 
   # https://xcb.freedesktop.org/manual/structxcb__xkb__get__map__reply__t.html
-  class X11GetMapReply < BinData::Record
+  class X11GetMapResponse < BinData::Record
     endian :little
     uint8 :reply
     uint8 :device_id
@@ -351,16 +351,14 @@ module Rex::Proto::X11::Xkeyboard
   end
 
   # https://xcb.freedesktop.org/manual/structxcb__query__keymap__reply__t.html
-  class X11QueryKeyMapReply < BinData::Record
+  class X11QueryKeyMapResponse < BinData::Record
     endian :little
     uint8 :reply
     uint8 :pad
     uint16 :sequence_number
     uint32 :response_length
     # byte sequence
-    array :data,
-          type: :uint8,
-          read_until: :eof
+    uint8_array :data, initial_length: 32
   end
 
   # https://xcb.freedesktop.org/manual/structxcb__xkb__bell__request__t.html

--- a/modules/auxiliary/scanner/x11/open_x11.rb
+++ b/modules/auxiliary/scanner/x11/open_x11.rb
@@ -50,7 +50,7 @@ class MetasploitModule < Msf::Auxiliary
     end
 
     if connection.header.success == 1
-      print_connection_info(connection, ip, rport)
+      x11_print_connection_info(connection, ip, rport)
       report_service(
         host: rhost,
         proto: 'tcp',


### PR DESCRIPTION
This makes the following changes:

* Adds the new `#x11_read_response` which handles chunked replies with a timeout
* Changes things to use the new `#x11_read_response` method
* Refactors some response classes to consistently refer to "Reply" objects as responses with a `response_length` field which is necessary for `#x11_read_response`
* Prefixed mixin methods with `x11_` to help scale things better in the future

Tested with Ubuntu 16.04